### PR TITLE
Correct comments to improve documentation

### DIFF
--- a/segment_list_test.go
+++ b/segment_list_test.go
@@ -280,7 +280,7 @@ func ExampleSegmentList_SetExif() {
 
 	sl := intfc.(*SegmentList)
 
-	// Update the UserComment tag.
+	// Update the DateTime tag.
 
 	rootIb, err := sl.ConstructExifBuilder()
 	log.PanicIf(err)
@@ -320,8 +320,6 @@ func TestSegmentList_ConstructExifBuilder(t *testing.T) {
 	log.PanicIf(err)
 
 	sl := intfc.(*SegmentList)
-
-	// Update the UserComment tag.
 
 	_, err = sl.ConstructExifBuilder()
 	log.PanicIf(err)

--- a/v2/segment_list_test.go
+++ b/v2/segment_list_test.go
@@ -283,7 +283,7 @@ func ExampleSegmentList_SetExif() {
 
 	sl := intfc.(*SegmentList)
 
-	// Update the UserComment tag.
+	// Update the CameraOwnerName tag.
 
 	rootIb, err := sl.ConstructExifBuilder()
 	log.PanicIf(err)


### PR DESCRIPTION
The auto-generated documentation pulls in the contents of various
'Example' functions, including comments. When looking at the docs, I
noticed that a comment in ExampleSegmentList_SetExif() incorrectly
claimed to be updating the 'UserComment' tag, likely due to being
copy/pasted from another function that does update this tag.

Here, correct the comments in both versions of
ExampleSegmentList_SetExif() to list the tags they are actually
updating.

For TestSegmentList_ConstructExifBuilder(t *testing.T) remove the
'Update the UserComment tag' comment entirely, as this function does not
update any tags.